### PR TITLE
Fix failing tests and verify

### DIFF
--- a/src/test/java/com/example/client/CursorsApiWireMockTest.java
+++ b/src/test/java/com/example/client/CursorsApiWireMockTest.java
@@ -42,7 +42,7 @@ public class CursorsApiWireMockTest {
         
         // Create API client pointing to WireMock server
         ApiClient apiClient = new ApiClient();
-        apiClient.setBasePath("http://localhost:8080");
+        apiClient.updateBaseUri("http://localhost:8080");
         cursorsApi = new CursorsApi(apiClient);
     }
 


### PR DESCRIPTION
Fix failing tests by using `updateBaseUri` instead of `setBasePath` in `CursorsApiWireMockTest`.

The `setBasePath` method was causing the base URL to be concatenated twice (e.g., `http://localhost:8080http://localhost:8080/...`) because the `ApiClient` already parses and stores the scheme/host/port from the default base URI. Using `updateBaseUri` correctly modifies the base URI without duplication.

---
<a href="https://cursor.com/background-agent?bcId=bc-96dfe1cc-4366-4ac1-848a-59c4c51b852f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96dfe1cc-4366-4ac1-848a-59c4c51b852f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

